### PR TITLE
Чинит конфиг линтера

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,9 +1,9 @@
 name: Go
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,11 +12,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: "1.22"
       - name: Build
         run: go build -v ./...
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.56.2
+          version: v1.64.5
           args: -c .golangci.yaml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,8 @@
+version: "2"
 linters:
-  disable-all: true
   enable:
+    - govet # Catches suspicious constructs
+    - staticcheck #  catches bugs, unused code, best practices
     - errcheck # checking for unchecked errors
     - unused # checks Go code for unused constants, variables, functions and types
     - prealloc # finds slice declarations that could potentially be pre-allocated
@@ -11,3 +13,6 @@ linters:
     - goimports # Checks if the code and import statements are formatted according to the 'goimports' command
     - lll # reports long lines
     - rowserrcheck # checks whether Rows.Err of rows is checked successfully
+    - gosimple # Detects overly complex code that can be simplified
+    # - revive # Enable after old code is removed
+    # - gosec # Security linter. Enable later.


### PR DESCRIPTION
На старую версию конфига редактор ругается из-за устаревшей конструкции disable-all и отсутствия тега версии.

* Обновил версию конфига
* Обновил версию линтера
* Убрал инструкцию disable-all
* Добавил несколько полезных линтеров

Revive и gosec отключил пока, чтобы они не ругались на старый код, нужно будет включить их после того, как старый код будет исправлен или удалён.

Автопроверки ругаются на устаревший s3-метод, это надо пофиксить в рамках отдельной задачи