### PR TITLE
Успокоение линтеров

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,5 +14,5 @@ linters:
     - lll # reports long lines
     - rowserrcheck # checks whether Rows.Err of rows is checked successfully
     - gosimple # Detects overly complex code that can be simplified
-    # - revive # Enable after old code is removed
-    # - gosec # Security linter. Enable later.
+    - revive # Enable after old code is removed
+    - gosec # Security linter. Enable later.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ linters:
     - prealloc # finds slice declarations that could potentially be pre-allocated
     - bodyclose # checks whether HTTP response body is closed successfully
     - cyclop # checks function and package cyclomatic complexity
+    - gocognit # checks function cognitive complexity
     - godox # tool for detection of F*IXME, T*ODO and other comment keywords
     - gofmt # checks if the code is formatted according to 'gofmt' command
     - goimports # Checks if the code and import statements are formatted according to the 'goimports' command

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -47,16 +47,16 @@ func initializeApp(cfg *config.Config, db *sqlx.DB, log *zap.Logger) *gin.Engine
 	tokenRepository := repository.NewTokenRepository(db)
 	log.Info("Repositories initialized")
 
-	productService := product.NewProductService(productRepository)
-	offerService := offer.NewOfferService(offerRepository)
-	tokenService := token.NewTokenService(
+	productService := product.NewService(productRepository)
+	offerService := offer.NewService(offerRepository)
+	tokenService := token.NewService(
 		tokenRepository,
 		cfg.Token.Secret,
 		cfg.Token.AccessTokenDuration,
 		cfg.Token.RefreshTokenDuration,
 	)
-	userService := user.NewUserService(userRepository, tokenService)
-	notificationService := notification.NewNotificationService(notificationRepository)
+	userService := user.NewService(userRepository, tokenService)
+	notificationService := notification.NewService(notificationRepository)
 	log.Info("Services initialized")
 
 	healthHandler := handler.NewHealthHandler()

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -49,7 +49,12 @@ func initializeApp(cfg *config.Config, db *sqlx.DB, log *zap.Logger) *gin.Engine
 
 	productService := product.NewProductService(productRepository)
 	offerService := offer.NewOfferService(offerRepository)
-	tokenService := token.NewTokenService(tokenRepository, cfg.Token.Secret, cfg.Token.AccessTokenDuration, cfg.Token.RefreshTokenDuration)
+	tokenService := token.NewTokenService(
+		tokenRepository,
+		cfg.Token.Secret,
+		cfg.Token.AccessTokenDuration,
+		cfg.Token.RefreshTokenDuration,
+	)
 	userService := user.NewUserService(userRepository, tokenService)
 	notificationService := notification.NewNotificationService(notificationRepository)
 	log.Info("Services initialized")

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -26,8 +26,8 @@ func main() {
 	log := logger.SetupLogger(cfg.Environment)
 	log.Info("Logger initialized")
 
-	db, close := database.InitDB(&cfg.DB)
-	defer close()
+	db, closer := database.InitDB(&cfg.DB)
+	defer closer()
 
 	migrator.RunMigrationsWithZap(db, "migrations", log)
 

--- a/internal/domain/service/notification/notification.go
+++ b/internal/domain/service/notification/notification.go
@@ -6,14 +6,14 @@ type Repository interface {
 	SelectUserNotifications(id string, offset, limit int) ([]entity.Notification, int, error)
 }
 
-type NotificationService struct {
+type Service struct {
 	notificationRepository Repository
 }
 
-func NewNotificationService(notificationRepository Repository) *NotificationService {
-	return &NotificationService{notificationRepository}
+func NewService(notificationRepository Repository) *Service {
+	return &Service{notificationRepository}
 }
 
-func (ns *NotificationService) GetNotification(id string, offset int, limit int) ([]entity.Notification, int, error) {
+func (ns *Service) GetNotification(id string, offset int, limit int) ([]entity.Notification, int, error) {
 	return ns.notificationRepository.SelectUserNotifications(id, offset, limit)
 }

--- a/internal/domain/service/notification/notification.go
+++ b/internal/domain/service/notification/notification.go
@@ -6,14 +6,14 @@ type Repository interface {
 	SelectUserNotifications(id string, offset, limit int) ([]entity.Notification, int, error)
 }
 
-type notificationService struct {
+type NotificationService struct {
 	notificationRepository Repository
 }
 
-func NewNotificationService(notificationRepository Repository) *notificationService {
-	return &notificationService{notificationRepository}
+func NewNotificationService(notificationRepository Repository) *NotificationService {
+	return &NotificationService{notificationRepository}
 }
 
-func (ns *notificationService) GetNotification(id string, offset int, limit int) ([]entity.Notification, int, error) {
+func (ns *NotificationService) GetNotification(id string, offset int, limit int) ([]entity.Notification, int, error) {
 	return ns.notificationRepository.SelectUserNotifications(id, offset, limit)
 }

--- a/internal/domain/service/offer/offer.go
+++ b/internal/domain/service/offer/offer.go
@@ -14,29 +14,29 @@ type Repository interface {
 	DeleteOffer(ctx context.Context, offerID uint) (entity.Offer, error)
 }
 
-type offerService struct {
+type OfferService struct {
 	offerRepository Repository
 }
 
-func NewOfferService(offerRepository Repository) *offerService {
-	return &offerService{offerRepository: offerRepository}
+func NewOfferService(offerRepository Repository) *OfferService {
+	return &OfferService{offerRepository: offerRepository}
 }
 
-func (os *offerService) CreateOffer(
+func (os *OfferService) CreateOffer(
 	ctx context.Context,
 	offer Offer,
 ) (uint, error) {
 	return os.offerRepository.InsertOffer(ctx, offer)
 }
 
-func (os *offerService) GetOffer(
+func (os *OfferService) GetOffer(
 	ctx context.Context,
 	offerID uint,
 ) (entity.Offer, error) {
 	return os.offerRepository.GetOfferByID(ctx, offerID)
 }
 
-func (os *offerService) GetUserOffers(
+func (os *OfferService) GetUserOffers(
 	ctx context.Context,
 	userID uint,
 	limit,
@@ -45,7 +45,7 @@ func (os *offerService) GetUserOffers(
 	return os.offerRepository.SelectUserOffers(ctx, userID, limit, offset)
 }
 
-func (os *offerService) UpdateOfferStatus(
+func (os *OfferService) UpdateOfferStatus(
 	ctx context.Context,
 	offerID uint,
 	status string,
@@ -53,7 +53,7 @@ func (os *offerService) UpdateOfferStatus(
 	return os.offerRepository.UpdateOfferStatus(ctx, offerID, status)
 }
 
-func (os *offerService) DeleteOffer(
+func (os *OfferService) DeleteOffer(
 	ctx context.Context,
 	offerID uint,
 ) (entity.Offer, error) {

--- a/internal/domain/service/offer/offer.go
+++ b/internal/domain/service/offer/offer.go
@@ -14,29 +14,29 @@ type Repository interface {
 	DeleteOffer(ctx context.Context, offerID uint) (entity.Offer, error)
 }
 
-type OfferService struct {
+type Service struct {
 	offerRepository Repository
 }
 
-func NewOfferService(offerRepository Repository) *OfferService {
-	return &OfferService{offerRepository: offerRepository}
+func NewService(offerRepository Repository) *Service {
+	return &Service{offerRepository: offerRepository}
 }
 
-func (os *OfferService) CreateOffer(
+func (os *Service) CreateOffer(
 	ctx context.Context,
 	offer Offer,
 ) (uint, error) {
 	return os.offerRepository.InsertOffer(ctx, offer)
 }
 
-func (os *OfferService) GetOffer(
+func (os *Service) GetOffer(
 	ctx context.Context,
 	offerID uint,
 ) (entity.Offer, error) {
 	return os.offerRepository.GetOfferByID(ctx, offerID)
 }
 
-func (os *OfferService) GetUserOffers(
+func (os *Service) GetUserOffers(
 	ctx context.Context,
 	userID uint,
 	limit,
@@ -45,7 +45,7 @@ func (os *OfferService) GetUserOffers(
 	return os.offerRepository.SelectUserOffers(ctx, userID, limit, offset)
 }
 
-func (os *OfferService) UpdateOfferStatus(
+func (os *Service) UpdateOfferStatus(
 	ctx context.Context,
 	offerID uint,
 	status string,
@@ -53,7 +53,7 @@ func (os *OfferService) UpdateOfferStatus(
 	return os.offerRepository.UpdateOfferStatus(ctx, offerID, status)
 }
 
-func (os *OfferService) DeleteOffer(
+func (os *Service) DeleteOffer(
 	ctx context.Context,
 	offerID uint,
 ) (entity.Offer, error) {

--- a/internal/domain/service/product/product.go
+++ b/internal/domain/service/product/product.go
@@ -14,29 +14,29 @@ type Repository interface {
 	UpdateProduct(ctx context.Context, id string, update UpdateProduct) error
 }
 
-type productService struct {
+type ProductService struct {
 	productRepository Repository
 }
 
-func NewProductService(productRepo Repository) *productService {
-	return &productService{productRepository: productRepo}
+func NewProductService(productRepo Repository) *ProductService {
+	return &ProductService{productRepository: productRepo}
 }
 
-func (ps *productService) CreateProduct(
+func (ps *ProductService) CreateProduct(
 	ctx context.Context,
 	product Product,
 ) (uint, error) {
 	return ps.productRepository.InsertProduct(ctx, product)
 }
 
-func (ps *productService) GetProductByID(
+func (ps *ProductService) GetProductByID(
 	ctx context.Context,
 	id string,
 ) (entity.Product, error) {
 	return ps.productRepository.GetProductByID(ctx, id)
 }
 
-func (ps *productService) GetProducts(
+func (ps *ProductService) GetProducts(
 	ctx context.Context,
 	offset,
 	limit int,
@@ -44,7 +44,7 @@ func (ps *productService) GetProducts(
 	return ps.productRepository.SelectProducts(ctx, offset, limit)
 }
 
-func (ps *productService) GetStoreProducts(
+func (ps *ProductService) GetStoreProducts(
 	ctx context.Context,
 	id string,
 	offset,
@@ -53,7 +53,7 @@ func (ps *productService) GetStoreProducts(
 	return ps.productRepository.SelectStoreProducts(ctx, id, offset, limit)
 }
 
-func (ps *productService) UpdateProduct(
+func (ps *ProductService) UpdateProduct(
 	ctx context.Context,
 	id string,
 	updateProduct UpdateProduct,

--- a/internal/domain/service/product/product.go
+++ b/internal/domain/service/product/product.go
@@ -14,29 +14,29 @@ type Repository interface {
 	UpdateProduct(ctx context.Context, id string, update UpdateProduct) error
 }
 
-type ProductService struct {
+type Service struct {
 	productRepository Repository
 }
 
-func NewProductService(productRepo Repository) *ProductService {
-	return &ProductService{productRepository: productRepo}
+func NewService(productRepo Repository) *Service {
+	return &Service{productRepository: productRepo}
 }
 
-func (ps *ProductService) CreateProduct(
+func (ps *Service) CreateProduct(
 	ctx context.Context,
 	product Product,
 ) (uint, error) {
 	return ps.productRepository.InsertProduct(ctx, product)
 }
 
-func (ps *ProductService) GetProductByID(
+func (ps *Service) GetProductByID(
 	ctx context.Context,
 	id string,
 ) (entity.Product, error) {
 	return ps.productRepository.GetProductByID(ctx, id)
 }
 
-func (ps *ProductService) GetProducts(
+func (ps *Service) GetProducts(
 	ctx context.Context,
 	offset,
 	limit int,
@@ -44,7 +44,7 @@ func (ps *ProductService) GetProducts(
 	return ps.productRepository.SelectProducts(ctx, offset, limit)
 }
 
-func (ps *ProductService) GetStoreProducts(
+func (ps *Service) GetStoreProducts(
 	ctx context.Context,
 	id string,
 	offset,
@@ -53,7 +53,7 @@ func (ps *ProductService) GetStoreProducts(
 	return ps.productRepository.SelectStoreProducts(ctx, id, offset, limit)
 }
 
-func (ps *ProductService) UpdateProduct(
+func (ps *Service) UpdateProduct(
 	ctx context.Context,
 	id string,
 	updateProduct UpdateProduct,

--- a/internal/domain/service/token/token.go
+++ b/internal/domain/service/token/token.go
@@ -24,15 +24,15 @@ type Repository interface {
 	Update(ctx context.Context, refresh entity.RefreshToken) (entity.RefreshToken, error)
 }
 
-type TokenService struct {
+type Service struct {
 	tokenRepository Repository
 	jwtSecret       string
 	refreshLife     time.Duration
 	accessLife      time.Duration
 }
 
-func NewTokenService(tokenRepo Repository, secret string, refreshLife, accessLife time.Duration) *TokenService {
-	return &TokenService{
+func NewService(tokenRepo Repository, secret string, refreshLife, accessLife time.Duration) *Service {
+	return &Service{
 		tokenRepository: tokenRepo,
 		jwtSecret:       secret,
 		refreshLife:     refreshLife,
@@ -41,7 +41,7 @@ func NewTokenService(tokenRepo Repository, secret string, refreshLife, accessLif
 }
 
 // GenerateTokens генерирует новый токен доступа и токен обновления для пользователя.
-func (ts *TokenService) GenerateTokens(
+func (ts *Service) GenerateTokens(
 	ctx context.Context,
 	fingerprint string,
 	userID uint,
@@ -69,7 +69,7 @@ func (ts *TokenService) GenerateTokens(
 }
 
 // ValidateToken проверяет access токен и возвращает расшифрованную информацию, если она действительна.
-func (ts *TokenService) ValidateToken(
+func (ts *Service) ValidateToken(
 	ctx context.Context,
 	token string,
 ) (entity.AccessToken, error) {
@@ -91,7 +91,7 @@ func (ts *TokenService) ValidateToken(
 }
 
 // parse извлекает токен JWT и извлекает claims.
-func (ts *TokenService) parse(token string) (entity.AccessToken, error) {
+func (ts *Service) parse(token string) (entity.AccessToken, error) {
 	claim := jwt.MapClaims{}
 	_, err := jwt.ParseWithClaims(token, claim, func(token *jwt.Token) (any, error) {
 		if token.Header["alg"] != signingMethod.Alg() {
@@ -127,7 +127,7 @@ func (ts *TokenService) parse(token string) (entity.AccessToken, error) {
 	}, nil
 }
 
-func (ts *TokenService) InsertToken(
+func (ts *Service) InsertToken(
 	ctx context.Context,
 	token entity.RefreshToken,
 ) error {
@@ -135,7 +135,7 @@ func (ts *TokenService) InsertToken(
 }
 
 // GetActivesTokenByUserID извлекает все активные токены обновления для конкретного пользователя.
-func (ts *TokenService) GetActivesTokenByUserID(
+func (ts *Service) GetActivesTokenByUserID(
 	ctx context.Context,
 	userID uint,
 ) ([]entity.RefreshToken, error) {
@@ -143,21 +143,21 @@ func (ts *TokenService) GetActivesTokenByUserID(
 }
 
 // RevokeActivesByUserID аннулирует все активные токены обновления для определенного пользователя.
-func (ts *TokenService) RevokeActivesByUserID(
+func (ts *Service) RevokeActivesByUserID(
 	ctx context.Context,
 	userID uint,
 ) error {
 	return ts.tokenRepository.RevokeActivesByUserID(ctx, userID)
 }
 
-func (ts *TokenService) GetByUUID(
+func (ts *Service) GetByUUID(
 	ctx context.Context,
 	uuid string,
 ) (entity.RefreshToken, error) {
 	return ts.tokenRepository.GetByUUID(ctx, uuid)
 }
 
-func (ts *TokenService) Update(
+func (ts *Service) Update(
 	ctx context.Context,
 	refresh entity.RefreshToken,
 ) (entity.RefreshToken, error) {

--- a/internal/domain/service/token/token.go
+++ b/internal/domain/service/token/token.go
@@ -24,15 +24,15 @@ type Repository interface {
 	Update(ctx context.Context, refresh entity.RefreshToken) (entity.RefreshToken, error)
 }
 
-type tokenService struct {
+type TokenService struct {
 	tokenRepository Repository
 	jwtSecret       string
 	refreshLife     time.Duration
 	accessLife      time.Duration
 }
 
-func NewTokenService(tokenRepo Repository, secret string, refreshLife, accessLife time.Duration) *tokenService {
-	return &tokenService{
+func NewTokenService(tokenRepo Repository, secret string, refreshLife, accessLife time.Duration) *TokenService {
+	return &TokenService{
 		tokenRepository: tokenRepo,
 		jwtSecret:       secret,
 		refreshLife:     refreshLife,
@@ -41,7 +41,7 @@ func NewTokenService(tokenRepo Repository, secret string, refreshLife, accessLif
 }
 
 // GenerateTokens генерирует новый токен доступа и токен обновления для пользователя.
-func (ts *tokenService) GenerateTokens(
+func (ts *TokenService) GenerateTokens(
 	ctx context.Context,
 	fingerprint string,
 	userID uint,
@@ -60,7 +60,7 @@ func (ts *tokenService) GenerateTokens(
 }
 
 // ValidateToken проверяет access токен и возвращает расшифрованную информацию, если она действительна.
-func (ts *tokenService) ValidateToken(
+func (ts *TokenService) ValidateToken(
 	ctx context.Context,
 	token string,
 ) (entity.AccessToken, error) {
@@ -77,7 +77,7 @@ func (ts *tokenService) ValidateToken(
 }
 
 // parse извлекает токен JWT и извлекает claims.
-func (ts *tokenService) parse(token string) (entity.AccessToken, error) {
+func (ts *TokenService) parse(token string) (entity.AccessToken, error) {
 	claim := jwt.MapClaims{}
 	_, err := jwt.ParseWithClaims(token, claim, func(token *jwt.Token) (any, error) {
 		if token.Header["alg"] != signingMethod.Alg() {
@@ -113,7 +113,7 @@ func (ts *tokenService) parse(token string) (entity.AccessToken, error) {
 	}, nil
 }
 
-func (ts *tokenService) InsertToken(
+func (ts *TokenService) InsertToken(
 	ctx context.Context,
 	token entity.RefreshToken,
 ) error {
@@ -121,7 +121,7 @@ func (ts *tokenService) InsertToken(
 }
 
 // GetActivesTokenByUserID извлекает все активные токены обновления для конкретного пользователя.
-func (ts *tokenService) GetActivesTokenByUserID(
+func (ts *TokenService) GetActivesTokenByUserID(
 	ctx context.Context,
 	userID uint,
 ) ([]entity.RefreshToken, error) {
@@ -129,21 +129,21 @@ func (ts *tokenService) GetActivesTokenByUserID(
 }
 
 // RevokeActivesByUserID аннулирует все активные токены обновления для определенного пользователя.
-func (ts *tokenService) RevokeActivesByUserID(
+func (ts *TokenService) RevokeActivesByUserID(
 	ctx context.Context,
 	userID uint,
 ) error {
 	return ts.tokenRepository.RevokeActivesByUserID(ctx, userID)
 }
 
-func (ts *tokenService) GetByUUID(
+func (ts *TokenService) GetByUUID(
 	ctx context.Context,
 	uuid string,
 ) (entity.RefreshToken, error) {
 	return ts.tokenRepository.GetByUUID(ctx, uuid)
 }
 
-func (ts *tokenService) Update(
+func (ts *TokenService) Update(
 	ctx context.Context,
 	refresh entity.RefreshToken,
 ) (entity.RefreshToken, error) {

--- a/internal/domain/service/token/token.go
+++ b/internal/domain/service/token/token.go
@@ -46,9 +46,18 @@ func (ts *TokenService) GenerateTokens(
 	fingerprint string,
 	userID uint,
 ) (string, entity.RefreshToken, error) {
+
+	if ctx.Err() != nil {
+		return "", entity.RefreshToken{}, ctx.Err()
+	}
+
 	accessToken, err := generateJWT(userID, ts.jwtSecret, ts.accessLife)
 	if err != nil {
 		return "", entity.RefreshToken{}, err
+	}
+
+	if ctx.Err() != nil {
+		return "", entity.RefreshToken{}, ctx.Err()
 	}
 
 	entityRefreshToken, err := generateRefresh(fingerprint, userID, ts.refreshLife)
@@ -64,6 +73,11 @@ func (ts *TokenService) ValidateToken(
 	ctx context.Context,
 	token string,
 ) (entity.AccessToken, error) {
+
+	if ctx.Err() != nil {
+		return entity.AccessToken{}, ctx.Err()
+	}
+
 	accessToken, err := ts.parse(token)
 	if err != nil {
 		return entity.AccessToken{}, err

--- a/internal/domain/service/token/token_test.go
+++ b/internal/domain/service/token/token_test.go
@@ -23,7 +23,7 @@ func TestNewTokenService(t *testing.T) {
 	refreshLife := 24 * time.Hour
 	accessLife := time.Hour
 
-	service := NewTokenService(repo, secret, refreshLife, accessLife)
+	service := NewService(repo, secret, refreshLife, accessLife)
 
 	assert.NotNil(t, service)
 	assert.Equal(t, repo, service.tokenRepository)
@@ -37,7 +37,7 @@ func TestTokenService_GenerateTokens(t *testing.T) {
 	defer ctrl.Finish()
 
 	repo := NewMockRepository(ctrl)
-	service := NewTokenService(repo, "test-secret", 24*time.Hour, time.Hour)
+	service := NewService(repo, "test-secret", 24*time.Hour, time.Hour)
 
 	tests := []struct {
 		name        string
@@ -77,7 +77,7 @@ func TestTokenService_ValidateToken(t *testing.T) {
 
 	repo := NewMockRepository(ctrl)
 	secret := "test-secret"
-	service := NewTokenService(repo, secret, 24*time.Hour, time.Hour)
+	service := NewService(repo, secret, 24*time.Hour, time.Hour)
 
 	validToken, err := generateJWT(1, secret, time.Hour)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestTokenService_Repository_Methods(t *testing.T) {
 	defer ctrl.Finish()
 
 	repo := NewMockRepository(ctrl)
-	service := NewTokenService(repo, "test-secret", 24*time.Hour, time.Hour)
+	service := NewService(repo, "test-secret", 24*time.Hour, time.Hour)
 	ctx := context.Background()
 
 	refreshToken := entity.RefreshToken{
@@ -180,7 +180,7 @@ func TestTokenService_Parse(t *testing.T) {
 
 	repo := NewMockRepository(ctrl)
 	secret := "test-secret"
-	service := NewTokenService(repo, secret, 24*time.Hour, time.Hour)
+	service := NewService(repo, secret, 24*time.Hour, time.Hour)
 
 	tests := []struct {
 		name    string

--- a/internal/domain/service/user/user.go
+++ b/internal/domain/service/user/user.go
@@ -30,18 +30,18 @@ type TokenService interface {
 	Update(ctx context.Context, refresh entity.RefreshToken) (entity.RefreshToken, error)
 }
 
-type userService struct {
+type UserService struct {
 	userRepository Repository
 	tokenService   TokenService
 }
 
-func NewUserService(userRepo Repository, tokenService TokenService) *userService {
-	return &userService{userRepository: userRepo, tokenService: tokenService}
+func NewUserService(userRepo Repository, tokenService TokenService) *UserService {
+	return &UserService{userRepository: userRepo, tokenService: tokenService}
 }
 
 // CreateUser создает пользователя, хэшируя его пароль, используя HashArgon2id
 // генерирует access токен и uuid refresh uuid.
-func (us *userService) CreateUser(
+func (us *UserService) CreateUser(
 	ctx context.Context,
 	user User,
 	fingerprint string,
@@ -72,7 +72,7 @@ func (us *userService) CreateUser(
 }
 
 // Authenticate аутентифицирует пользователя по email и паролю, создавая новые токены.
-func (us *userService) Authenticate(
+func (us *UserService) Authenticate(
 	ctx context.Context,
 	email,
 	password,
@@ -117,7 +117,7 @@ func (us *userService) Authenticate(
 }
 
 // Refresh обновляет пару токенов аутентификации.
-func (us *userService) Refresh(
+func (us *UserService) Refresh(
 	ctx context.Context,
 	refreshToken,
 	fingerprint string,
@@ -161,7 +161,7 @@ func (us *userService) Refresh(
 	return access, refresh.UUID.String(), nil
 }
 
-func (us *userService) Logout(
+func (us *UserService) Logout(
 	ctx context.Context,
 	refreshToken,
 	fingerprint string,
@@ -190,6 +190,6 @@ func (us *userService) Logout(
 	return nil
 }
 
-func (us *userService) GetUserByID(ctx context.Context, id uint) (entity.User, error) {
+func (us *UserService) GetUserByID(ctx context.Context, id uint) (entity.User, error) {
 	return us.userRepository.GetUserByID(ctx, id)
 }

--- a/internal/domain/service/user/user.go
+++ b/internal/domain/service/user/user.go
@@ -30,18 +30,18 @@ type TokenService interface {
 	Update(ctx context.Context, refresh entity.RefreshToken) (entity.RefreshToken, error)
 }
 
-type UserService struct {
+type Service struct {
 	userRepository Repository
 	tokenService   TokenService
 }
 
-func NewUserService(userRepo Repository, tokenService TokenService) *UserService {
-	return &UserService{userRepository: userRepo, tokenService: tokenService}
+func NewService(userRepo Repository, tokenService TokenService) *Service {
+	return &Service{userRepository: userRepo, tokenService: tokenService}
 }
 
 // CreateUser создает пользователя, хэшируя его пароль, используя HashArgon2id
 // генерирует access токен и uuid refresh uuid.
-func (us *UserService) CreateUser(
+func (us *Service) CreateUser(
 	ctx context.Context,
 	user User,
 	fingerprint string,
@@ -72,7 +72,7 @@ func (us *UserService) CreateUser(
 }
 
 // Authenticate аутентифицирует пользователя по email и паролю, создавая новые токены.
-func (us *UserService) Authenticate(
+func (us *Service) Authenticate(
 	ctx context.Context,
 	email,
 	password,
@@ -117,7 +117,7 @@ func (us *UserService) Authenticate(
 }
 
 // Refresh обновляет пару токенов аутентификации.
-func (us *UserService) Refresh(
+func (us *Service) Refresh(
 	ctx context.Context,
 	refreshToken,
 	fingerprint string,
@@ -161,7 +161,7 @@ func (us *UserService) Refresh(
 	return access, refresh.UUID.String(), nil
 }
 
-func (us *UserService) Logout(
+func (us *Service) Logout(
 	ctx context.Context,
 	refreshToken,
 	fingerprint string,
@@ -190,6 +190,6 @@ func (us *UserService) Logout(
 	return nil
 }
 
-func (us *UserService) GetUserByID(ctx context.Context, id uint) (entity.User, error) {
+func (us *Service) GetUserByID(ctx context.Context, id uint) (entity.User, error) {
 	return us.userRepository.GetUserByID(ctx, id)
 }

--- a/internal/domain/service/user/user_test.go
+++ b/internal/domain/service/user/user_test.go
@@ -21,7 +21,7 @@ func TestUserService_CreateUser(t *testing.T) {
 
 	mockRepo := NewMockRepository(ctrl)
 	mockTokenService := NewMockTokenService(ctrl)
-	userService := NewUserService(mockRepo, mockTokenService)
+	userService := NewService(mockRepo, mockTokenService)
 
 	ctx := context.Background()
 	testUser := User{
@@ -85,7 +85,7 @@ func TestUserService_Authenticate(t *testing.T) {
 
 	mockRepo := NewMockRepository(ctrl)
 	mockTokenService := NewMockTokenService(ctrl)
-	userService := NewUserService(mockRepo, mockTokenService)
+	userService := NewService(mockRepo, mockTokenService)
 
 	ctx := context.Background()
 	email := "test@example.com"
@@ -218,7 +218,7 @@ func TestUserService_Refresh(t *testing.T) {
 
 	mockRepo := NewMockRepository(ctrl)
 	mockTokenService := NewMockTokenService(ctrl)
-	userService := NewUserService(mockRepo, mockTokenService)
+	userService := NewService(mockRepo, mockTokenService)
 
 	ctx := context.Background()
 	refreshTokenStr := uuid.New().String()
@@ -344,7 +344,7 @@ func TestUserService_Logout(t *testing.T) {
 
 	mockRepo := NewMockRepository(ctrl)
 	mockTokenService := NewMockTokenService(ctrl)
-	userService := NewUserService(mockRepo, mockTokenService)
+	userService := NewService(mockRepo, mockTokenService)
 
 	ctx := context.Background()
 	refreshTokenStr := uuid.New().String()
@@ -432,7 +432,7 @@ func TestUserService_GetUserByID(t *testing.T) {
 
 	mockRepo := NewMockRepository(ctrl)
 	mockTokenService := NewMockTokenService(ctrl)
-	userService := NewUserService(mockRepo, mockTokenService)
+	userService := NewService(mockRepo, mockTokenService)
 
 	ctx := context.Background()
 	userID := uint(1)

--- a/internal/domain/service/user/user_test.go
+++ b/internal/domain/service/user/user_test.go
@@ -54,7 +54,9 @@ func TestUserService_CreateUser(t *testing.T) {
 
 	t.Run("token generation failure", func(t *testing.T) {
 		mockRepo.EXPECT().InsertUser(ctx, gomock.Any()).Return(uint(1), nil)
-		mockTokenService.EXPECT().GenerateTokens(ctx, fingerprint, uint(1)).Return("", entity.RefreshToken{}, errors.New("token generation error"))
+		mockTokenService.EXPECT().
+			GenerateTokens(ctx, fingerprint, uint(1)).
+			Return("", entity.RefreshToken{}, errors.New("token generation error"))
 
 		accessToken, refreshToken, err := userService.CreateUser(ctx, testUser, fingerprint)
 
@@ -101,8 +103,12 @@ func TestUserService_Authenticate(t *testing.T) {
 
 	t.Run("successful authentication", func(t *testing.T) {
 		mockRepo.EXPECT().GetUser(ctx, email).Return(testUser, nil)
-		mockTokenService.EXPECT().GetActivesTokenByUserID(ctx, testUser.ID).Return([]entity.RefreshToken{}, nil)
-		mockTokenService.EXPECT().GenerateTokens(ctx, fingerprint, testUser.ID).Return("access-token", entity.RefreshToken{}, nil)
+		mockTokenService.EXPECT().
+			GetActivesTokenByUserID(ctx, testUser.ID).
+			Return([]entity.RefreshToken{}, nil)
+		mockTokenService.EXPECT().
+			GenerateTokens(ctx, fingerprint, testUser.ID).
+			Return("access-token", entity.RefreshToken{}, nil)
 		mockTokenService.EXPECT().InsertToken(ctx, gomock.Any()).Return(nil)
 
 		accessToken, refreshToken, err := userService.Authenticate(ctx, email, password, fingerprint)
@@ -139,7 +145,9 @@ func TestUserService_Authenticate(t *testing.T) {
 		mockRepo.EXPECT().GetUser(ctx, email).Return(testUser, nil)
 		mockTokenService.EXPECT().GetActivesTokenByUserID(ctx, testUser.ID).Return(maxTokens, nil)
 		mockTokenService.EXPECT().RevokeActivesByUserID(ctx, testUser.ID).Return(nil)
-		mockTokenService.EXPECT().GenerateTokens(ctx, fingerprint, testUser.ID).Return("access-token", entity.RefreshToken{}, nil)
+		mockTokenService.EXPECT().
+			GenerateTokens(ctx, fingerprint, testUser.ID).
+			Return("access-token", entity.RefreshToken{}, nil)
 		mockTokenService.EXPECT().InsertToken(ctx, gomock.Any()).Return(nil)
 
 		accessToken, refreshToken, err := userService.Authenticate(ctx, email, password, fingerprint)
@@ -228,7 +236,9 @@ func TestUserService_Refresh(t *testing.T) {
 		mockTokenService.EXPECT().GetByUUID(ctx, refreshTokenStr).Return(validRefreshToken, nil)
 		mockTokenService.EXPECT().Update(ctx, gomock.Any()).Return(validRefreshToken, nil)
 		mockRepo.EXPECT().GetUserByID(ctx, userID).Return(entity.User{ID: userID}, nil)
-		mockTokenService.EXPECT().GenerateTokens(ctx, fingerprint, userID).Return("new-access-token", entity.RefreshToken{}, nil)
+		mockTokenService.EXPECT().
+			GenerateTokens(ctx, fingerprint, userID).
+			Return("new-access-token", entity.RefreshToken{}, nil)
 		mockTokenService.EXPECT().InsertToken(ctx, gomock.Any()).Return(nil)
 
 		accessToken, newRefreshToken, err := userService.Refresh(ctx, refreshTokenStr, fingerprint)

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -26,11 +26,11 @@ import (
 // @Success 200 {object} map[string]interface{} "Успешный ответ с данными"
 // @Router /health [get]
 func SetupRouter(
-	healthH *healthHandler,
-	productH *productHandler,
-	offerH *offerHandler,
-	userH *userHandler,
-	notificationH *notificationHandler,
+	healthH *HealthHandler,
+	productH *ProductHandler,
+	offerH *OfferHandler,
+	userH *UserHandler,
+	notificationH *NotificationHandler,
 	userS middleware.UserGetter,
 	tokenS middleware.TokenValidator,
 	basePath string,

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -58,7 +58,8 @@ func SetupRouter(
 	auth := base.Group("/auth")
 	userH.RegisterRoutes(auth)
 
-	// TODO: не забыть зарегистрировать роуты для продуктов, офферов и уведомлений
+	// Заглушки для нереализованных хендлеров.
+	// Не забудьте убрать их и добавить вызов .RegisterRoutes для каждого хендлера
 	_ = productH
 	_ = offerH
 	_ = notificationH

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	// Импорт сваггер-генератора
 	_ "github.com/EM-Stawberry/Stawberry/docs"
 	"github.com/EM-Stawberry/Stawberry/internal/handler/middleware"
 	swaggerFiles "github.com/swaggo/files"

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -57,6 +57,11 @@ func SetupRouter(
 	auth := base.Group("/auth")
 	userH.RegisterRoutes(auth)
 
+	// TODO: не забыть зарегистрировать роуты для продуктов, офферов и уведомлений
+	_ = productH
+	_ = offerH
+	_ = notificationH
+
 	secured := base.Use(middleware.AuthMiddleware(userS, tokenS))
 	{
 		secured.GET("/auth_required", func(c *gin.Context) {

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -7,20 +7,20 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type healthHandler struct {
+type HealthHandler struct {
 }
 
-func NewHealthHandler() *healthHandler {
-	return &healthHandler{}
+func NewHealthHandler() *HealthHandler {
+	return &HealthHandler{}
 }
 
-func (h *healthHandler) health(c *gin.Context) {
+func (h *HealthHandler) health(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 		"time":   time.Now().Unix(),
 	})
 }
 
-func (h *healthHandler) RegisterRoutes(group gin.IRoutes) {
+func (h *HealthHandler) RegisterRoutes(group gin.IRoutes) {
 	group.GET("/health", h.health)
 }

--- a/internal/handler/middleware/logger.go
+++ b/internal/handler/middleware/logger.go
@@ -57,7 +57,9 @@ func statusCodeColor(code int) string {
 }
 
 // ginRoutesRegex matches Gin's debug route definitions
-var ginRoutesRegex = regexp.MustCompile(`(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|CONNECT|TRACE)\s+(.+)\s+--> (.+) \((\d+) handlers\)`)
+var ginRoutesRegex = regexp.MustCompile(
+	`(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|CONNECT|TRACE)` +
+		`\s+(.+)\s+--> (.+) \((\d+) handlers\)`)
 
 func formatGinDebugMessage(s string) string {
 	if matches := ginRoutesRegex.FindStringSubmatch(s); len(matches) == 5 {
@@ -78,7 +80,9 @@ func formatGinDebugMessage(s string) string {
 			padding = 1
 		}
 
-		return colorPink + "[Strawberry]" + colorPink + " " + prefix + path + strings.Repeat(" ", padding) + colorCyan + "→" + colorReset + " " + colorReset + shortHandler + colorReset
+		return colorPink + "[Strawberry]" +
+			colorPink + " " + prefix + path + strings.Repeat(" ", padding) +
+			colorCyan + "→" + colorReset + " " + colorReset + shortHandler + colorReset
 	}
 
 	s = strings.TrimPrefix(s, "[GIN-debug] ")

--- a/internal/handler/notification.go
+++ b/internal/handler/notification.go
@@ -55,7 +55,7 @@ func (h *NotificationHandler) GetNotification(c *gin.Context) {
 	}
 	notifications, total, err := h.offerService.GetNotification(strconv.FormatUint(uint64(uid), 10), offset, limit)
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 

--- a/internal/handler/notification.go
+++ b/internal/handler/notification.go
@@ -13,17 +13,17 @@ type NotificationService interface {
 	GetNotification(id string, offset int, limit int) ([]entity.Notification, int, error)
 }
 
-type notificationHandler struct {
+type NotificationHandler struct {
 	offerService NotificationService
 }
 
-func NewNotificationHandler(notificationService NotificationService) *notificationHandler {
-	return &notificationHandler{offerService: notificationService}
+func NewNotificationHandler(notificationService NotificationService) *NotificationHandler {
+	return &NotificationHandler{offerService: notificationService}
 }
 
 // GetNotification обработчик уведомлений
 // получает все уведомления (одобрение или неодобрение заявки) авторизированного пользователя
-func (h *notificationHandler) GetNotification(c *gin.Context) {
+func (h *NotificationHandler) GetNotification(c *gin.Context) {
 	// сделать user, ok := c.Get("user")
 	// сейчас в контекст кладется userID, в будущем структура user
 	userID, ok := c.Get("userID")

--- a/internal/handler/offer.go
+++ b/internal/handler/offer.go
@@ -22,15 +22,15 @@ type OfferService interface {
 	DeleteOffer(ctx context.Context, offerID uint) (entity.Offer, error)
 }
 
-type offerHandler struct {
+type OfferHandler struct {
 	offerService OfferService
 }
 
-func NewOfferHandler(offerService OfferService) *offerHandler {
-	return &offerHandler{offerService: offerService}
+func NewOfferHandler(offerService OfferService) *OfferHandler {
+	return &OfferHandler{offerService: offerService}
 }
 
-func (h *offerHandler) PostOffer(c *gin.Context) {
+func (h *OfferHandler) PostOffer(c *gin.Context) {
 	userID, _ := c.Get("userID")
 
 	var offer dto.PostOfferReq
@@ -61,7 +61,7 @@ func (h *offerHandler) PostOffer(c *gin.Context) {
 	c.JSON(http.StatusCreated, offer)
 }
 
-func (h *offerHandler) GetUserOffers(c *gin.Context) {
+func (h *OfferHandler) GetUserOffers(c *gin.Context) {
 	userID, ok := c.Get("userID")
 	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid UserID"})
@@ -101,7 +101,7 @@ func (h *offerHandler) GetUserOffers(c *gin.Context) {
 	})
 }
 
-func (h *offerHandler) GetOffer(c *gin.Context) {
+func (h *OfferHandler) GetOffer(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid non digit offer id"})
@@ -119,7 +119,7 @@ func (h *offerHandler) GetOffer(c *gin.Context) {
 	})
 }
 
-func (h *offerHandler) PatchOfferStatus(c *gin.Context) {
+func (h *OfferHandler) PatchOfferStatus(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid nondigit offer id"})
@@ -150,7 +150,7 @@ func (h *offerHandler) PatchOfferStatus(c *gin.Context) {
 	c.JSON(http.StatusCreated, offer)
 }
 
-func (h *offerHandler) DeleteOffer(c *gin.Context) {
+func (h *OfferHandler) DeleteOffer(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid nondigit offer id"})

--- a/internal/handler/offer.go
+++ b/internal/handler/offer.go
@@ -46,7 +46,7 @@ func (h *OfferHandler) PostOffer(c *gin.Context) {
 	var response dto.PostOfferResp
 	var err error
 	if response.ID, err = h.offerService.CreateOffer(context.Background(), offer.ConvertToSvc()); err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -84,7 +84,7 @@ func (h *OfferHandler) GetUserOffers(c *gin.Context) {
 
 	offers, total, err := h.offerService.GetUserOffers(context.Background(), userID.(uint), offset, limit)
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -110,7 +110,7 @@ func (h *OfferHandler) GetOffer(c *gin.Context) {
 
 	offer, err := h.offerService.GetOffer(context.Background(), uint(id))
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -135,7 +135,7 @@ func (h *OfferHandler) PatchOfferStatus(c *gin.Context) {
 
 	offer, err := h.offerService.UpdateOfferStatus(context.Background(), uint(id), req.Status)
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -159,7 +159,7 @@ func (h *OfferHandler) DeleteOffer(c *gin.Context) {
 
 	offer, err := h.offerService.DeleteOffer(context.Background(), uint(id))
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 

--- a/internal/handler/offer.go
+++ b/internal/handler/offer.go
@@ -102,7 +102,7 @@ func (h *OfferHandler) GetUserOffers(c *gin.Context) {
 }
 
 func (h *OfferHandler) GetOffer(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid non digit offer id"})
 		return
@@ -120,7 +120,7 @@ func (h *OfferHandler) GetOffer(c *gin.Context) {
 }
 
 func (h *OfferHandler) PatchOfferStatus(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid nondigit offer id"})
 		return
@@ -151,7 +151,7 @@ func (h *OfferHandler) PatchOfferStatus(c *gin.Context) {
 }
 
 func (h *OfferHandler) DeleteOffer(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid nondigit offer id"})
 		return

--- a/internal/handler/product.go
+++ b/internal/handler/product.go
@@ -46,7 +46,7 @@ func (h *ProductHandler) PostProduct(c *gin.Context) {
 	var response dto.PostProductResp
 	var err error
 	if response.ID, err = h.productService.CreateProduct(context.Background(), postProductReq.ConvertToSvc()); err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -58,7 +58,7 @@ func (h *ProductHandler) GetProduct(c *gin.Context) {
 
 	product, err := h.productService.GetProductByID(context.Background(), id)
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -88,7 +88,7 @@ func (h *ProductHandler) GetProducts(c *gin.Context) {
 
 	products, total, err := h.productService.GetProducts(context.Background(), offset, limit)
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -130,7 +130,7 @@ func (h *ProductHandler) GetStoreProducts(c *gin.Context) {
 
 	products, total, err := h.productService.GetStoreProducts(context.Background(), id, offset, limit)
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -161,7 +161,7 @@ func (h *ProductHandler) PatchProduct(c *gin.Context) {
 	}
 
 	if err := h.productService.UpdateProduct(context.Background(), id, update.ConvertToSvc()); err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 

--- a/internal/handler/product.go
+++ b/internal/handler/product.go
@@ -23,15 +23,15 @@ type ProductService interface {
 	UpdateProduct(ctx context.Context, id string, updateProduct product.UpdateProduct) error
 }
 
-type productHandler struct {
+type ProductHandler struct {
 	productService ProductService
 }
 
-func NewProductHandler(productService ProductService) *productHandler {
-	return &productHandler{productService: productService}
+func NewProductHandler(productService ProductService) *ProductHandler {
+	return &ProductHandler{productService: productService}
 }
 
-func (h *productHandler) PostProduct(c *gin.Context) {
+func (h *ProductHandler) PostProduct(c *gin.Context) {
 	var postProductReq dto.PostProductReq
 
 	if err := c.ShouldBindJSON(&postProductReq); err != nil {
@@ -53,7 +53,7 @@ func (h *productHandler) PostProduct(c *gin.Context) {
 	c.JSON(http.StatusCreated, response)
 }
 
-func (h *productHandler) GetProduct(c *gin.Context) {
+func (h *ProductHandler) GetProduct(c *gin.Context) {
 	id := c.Param("id")
 
 	product, err := h.productService.GetProductByID(context.Background(), id)
@@ -65,7 +65,7 @@ func (h *productHandler) GetProduct(c *gin.Context) {
 	c.JSON(http.StatusOK, product)
 }
 
-func (h *productHandler) GetProducts(c *gin.Context) {
+func (h *ProductHandler) GetProducts(c *gin.Context) {
 	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
 	if err != nil || page < 1 {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -105,7 +105,7 @@ func (h *productHandler) GetProducts(c *gin.Context) {
 	})
 }
 
-func (h *productHandler) GetStoreProducts(c *gin.Context) {
+func (h *ProductHandler) GetStoreProducts(c *gin.Context) {
 	id := c.Param("id")
 
 	page, err := strconv.Atoi(c.DefaultQuery("page", "1"))
@@ -147,7 +147,7 @@ func (h *productHandler) GetStoreProducts(c *gin.Context) {
 	})
 }
 
-func (h *productHandler) PatchProduct(c *gin.Context) {
+func (h *ProductHandler) PatchProduct(c *gin.Context) {
 	id := c.Param("id")
 
 	var update dto.PatchProductReq

--- a/internal/handler/user.go
+++ b/internal/handler/user.go
@@ -22,7 +22,7 @@ type UserService interface {
 	GetUserByID(ctx context.Context, id uint) (entity.User, error)
 }
 
-type userHandler struct {
+type UserHandler struct {
 	userService UserService
 	refreshLife int
 	basePath    string
@@ -32,15 +32,15 @@ type userHandler struct {
 func NewUserHandler(
 	cfg *config.Config,
 	userService UserService,
-) *userHandler {
-	return &userHandler{
+) *UserHandler {
+	return &UserHandler{
 		userService: userService,
 		refreshLife: int(cfg.Token.RefreshTokenDuration),
 		domain:      cfg.Server.Domain,
 	}
 }
 
-func (h *userHandler) RegisterRoutes(group *gin.RouterGroup) {
+func (h *UserHandler) RegisterRoutes(group *gin.RouterGroup) {
 	h.basePath = group.BasePath()
 
 	group.POST("/reg", h.Registration)
@@ -49,7 +49,7 @@ func (h *userHandler) RegisterRoutes(group *gin.RouterGroup) {
 	group.POST("/refresh", h.Refresh)
 }
 
-func (h *userHandler) Registration(c *gin.Context) {
+func (h *UserHandler) Registration(c *gin.Context) {
 	var regUserDTO dto.RegistrationUserReq
 	if err := c.ShouldBindJSON(&regUserDTO); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -79,7 +79,7 @@ func (h *userHandler) Registration(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-func (h *userHandler) Login(c *gin.Context) {
+func (h *UserHandler) Login(c *gin.Context) {
 	var loginUserDTO dto.LoginUserReq
 	if err := c.ShouldBindJSON(&loginUserDTO); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -112,7 +112,7 @@ func (h *userHandler) Login(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-func (h *userHandler) Refresh(c *gin.Context) {
+func (h *UserHandler) Refresh(c *gin.Context) {
 	var refreshDTO dto.RefreshReq
 	if err := c.ShouldBindJSON(&refreshDTO); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -156,7 +156,7 @@ func (h *userHandler) Refresh(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-func (h *userHandler) Logout(c *gin.Context) {
+func (h *UserHandler) Logout(c *gin.Context) {
 	var logoutDTO dto.LogoutReq
 	if err := c.ShouldBindJSON(&logoutDTO); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{

--- a/internal/handler/user.go
+++ b/internal/handler/user.go
@@ -66,7 +66,7 @@ func (h *UserHandler) Registration(c *gin.Context) {
 		regUserDTO.Fingerprint,
 	)
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 	response := dto.RegistrationUserResp{
@@ -98,7 +98,7 @@ func (h *UserHandler) Login(c *gin.Context) {
 	)
 
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -142,7 +142,7 @@ func (h *UserHandler) Refresh(c *gin.Context) {
 		refreshDTO.Fingerprint,
 	)
 	if err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -185,7 +185,7 @@ func (h *UserHandler) Logout(c *gin.Context) {
 		logoutDTO.RefreshToken,
 		logoutDTO.Fingerprint,
 	); err != nil {
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 

--- a/internal/repository/database.go
+++ b/internal/repository/database.go
@@ -4,6 +4,8 @@ import (
 	"log"
 
 	"github.com/EM-Stawberry/Stawberry/config"
+
+	// Импорт драйвера для sqlx
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/jmoiron/sqlx"
 )

--- a/internal/repository/notification.go
+++ b/internal/repository/notification.go
@@ -20,5 +20,9 @@ func (r *NotificationRepository) SelectUserNotifications(
 ) ([]entity.Notification, int, error) {
 	var total int64
 
+	_ = id
+	_ = offset
+	_ = limit
+
 	return nil, int(total), nil
 }

--- a/internal/repository/notification.go
+++ b/internal/repository/notification.go
@@ -6,15 +6,15 @@ import (
 	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
 )
 
-type notificationRepository struct {
+type NotificationRepository struct {
 	db *sqlx.DB
 }
 
-func NewNotificationRepository(db *sqlx.DB) *notificationRepository {
-	return &notificationRepository{db: db}
+func NewNotificationRepository(db *sqlx.DB) *NotificationRepository {
+	return &NotificationRepository{db: db}
 }
 
-func (r *notificationRepository) SelectUserNotifications(
+func (r *NotificationRepository) SelectUserNotifications(
 	id string,
 	offset, limit int,
 ) ([]entity.Notification, int, error) {

--- a/internal/repository/offer.go
+++ b/internal/repository/offer.go
@@ -22,6 +22,9 @@ func (r *OfferRepository) InsertOffer(
 	offer offer.Offer,
 ) (uint, error) {
 
+	_ = ctx
+	_ = offer
+
 	return offer.ID, nil
 }
 
@@ -30,6 +33,9 @@ func (r *OfferRepository) GetOfferByID(
 	offerID uint,
 ) (entity.Offer, error) {
 	var offer entity.Offer
+
+	_ = ctx
+	_ = offerID
 
 	return offer, nil
 }
@@ -43,6 +49,11 @@ func (r *OfferRepository) SelectUserOffers(
 
 	var offers []entity.Offer
 
+	_ = ctx
+	_ = userID
+	_ = limit
+	_ = offset
+
 	return offers, total, nil
 }
 
@@ -54,6 +65,10 @@ func (r *OfferRepository) UpdateOfferStatus(
 
 	var offer entity.Offer
 
+	_ = ctx
+	_ = offerID
+	_ = status
+
 	return offer, nil
 }
 
@@ -62,6 +77,9 @@ func (r *OfferRepository) DeleteOffer(
 	offerID uint,
 ) (entity.Offer, error) {
 	var offer entity.Offer
+
+	_ = ctx
+	_ = offerID
 
 	return offer, nil
 }

--- a/internal/repository/offer.go
+++ b/internal/repository/offer.go
@@ -9,15 +9,15 @@ import (
 	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
 )
 
-type offerRepository struct {
+type OfferRepository struct {
 	db *sqlx.DB
 }
 
-func NewOfferRepository(db *sqlx.DB) *offerRepository {
-	return &offerRepository{db: db}
+func NewOfferRepository(db *sqlx.DB) *OfferRepository {
+	return &OfferRepository{db: db}
 }
 
-func (r *offerRepository) InsertOffer(
+func (r *OfferRepository) InsertOffer(
 	ctx context.Context,
 	offer offer.Offer,
 ) (uint, error) {
@@ -25,7 +25,7 @@ func (r *offerRepository) InsertOffer(
 	return offer.ID, nil
 }
 
-func (r *offerRepository) GetOfferByID(
+func (r *OfferRepository) GetOfferByID(
 	ctx context.Context,
 	offerID uint,
 ) (entity.Offer, error) {
@@ -34,7 +34,7 @@ func (r *offerRepository) GetOfferByID(
 	return offer, nil
 }
 
-func (r *offerRepository) SelectUserOffers(
+func (r *OfferRepository) SelectUserOffers(
 	ctx context.Context,
 	userID uint,
 	limit, offset int,
@@ -46,7 +46,7 @@ func (r *offerRepository) SelectUserOffers(
 	return offers, total, nil
 }
 
-func (r *offerRepository) UpdateOfferStatus(
+func (r *OfferRepository) UpdateOfferStatus(
 	ctx context.Context,
 	offerID uint,
 	status string,
@@ -57,7 +57,7 @@ func (r *offerRepository) UpdateOfferStatus(
 	return offer, nil
 }
 
-func (r *offerRepository) DeleteOffer(
+func (r *OfferRepository) DeleteOffer(
 	ctx context.Context,
 	offerID uint,
 ) (entity.Offer, error) {

--- a/internal/repository/product.go
+++ b/internal/repository/product.go
@@ -25,6 +25,9 @@ func (r *ProductRepository) InsertProduct(
 	product product.Product,
 ) (uint, error) {
 
+	_ = ctx
+	_ = product
+
 	return 0, nil
 }
 
@@ -35,6 +38,9 @@ func (r *ProductRepository) GetProductByID(
 
 	var produnilctModel model.Product
 
+	_ = ctx
+	_ = id
+
 	return model.ConvertProductToEntity(produnilctModel), nil
 }
 
@@ -44,6 +50,10 @@ func (r *ProductRepository) SelectProducts(
 	limit int,
 ) ([]entity.Product, int, error) {
 
+	_ = ctx
+	_ = offset
+	_ = limit
+
 	return nil, 0, nil
 }
 
@@ -51,6 +61,11 @@ func (r *ProductRepository) SelectStoreProducts(
 	ctx context.Context,
 	id string, offset, limit int,
 ) ([]entity.Product, int, error) {
+
+	_ = ctx
+	_ = id
+	_ = limit
+	_ = offset
 
 	return nil, 0, nil
 }
@@ -60,6 +75,10 @@ func (r *ProductRepository) UpdateProduct(
 	id string,
 	update product.UpdateProduct,
 ) error {
+
+	_ = ctx
+	_ = id
+	_ = update
 
 	return nil
 }

--- a/internal/repository/product.go
+++ b/internal/repository/product.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"strings"
 
 	"github.com/jmoiron/sqlx"
 
@@ -81,9 +80,4 @@ func (r *ProductRepository) UpdateProduct(
 	_ = update
 
 	return nil
-}
-
-func isDuplicateError(err error) bool {
-	return strings.Contains(err.Error(), "duplicate") ||
-		strings.Contains(err.Error(), "unique violation")
 }

--- a/internal/repository/product.go
+++ b/internal/repository/product.go
@@ -12,15 +12,15 @@ import (
 	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
 )
 
-type productRepository struct {
+type ProductRepository struct {
 	db *sqlx.DB
 }
 
-func NewProductRepository(db *sqlx.DB) *productRepository {
-	return &productRepository{db: db}
+func NewProductRepository(db *sqlx.DB) *ProductRepository {
+	return &ProductRepository{db: db}
 }
 
-func (r *productRepository) InsertProduct(
+func (r *ProductRepository) InsertProduct(
 	ctx context.Context,
 	product product.Product,
 ) (uint, error) {
@@ -28,7 +28,7 @@ func (r *productRepository) InsertProduct(
 	return 0, nil
 }
 
-func (r *productRepository) GetProductByID(
+func (r *ProductRepository) GetProductByID(
 	ctx context.Context,
 	id string,
 ) (entity.Product, error) {
@@ -38,7 +38,7 @@ func (r *productRepository) GetProductByID(
 	return model.ConvertProductToEntity(produnilctModel), nil
 }
 
-func (r *productRepository) SelectProducts(
+func (r *ProductRepository) SelectProducts(
 	ctx context.Context,
 	offset,
 	limit int,
@@ -47,7 +47,7 @@ func (r *productRepository) SelectProducts(
 	return nil, 0, nil
 }
 
-func (r *productRepository) SelectStoreProducts(
+func (r *ProductRepository) SelectStoreProducts(
 	ctx context.Context,
 	id string, offset, limit int,
 ) ([]entity.Product, int, error) {
@@ -55,7 +55,7 @@ func (r *productRepository) SelectStoreProducts(
 	return nil, 0, nil
 }
 
-func (r *productRepository) UpdateProduct(
+func (r *ProductRepository) UpdateProduct(
 	ctx context.Context,
 	id string,
 	update product.UpdateProduct,

--- a/internal/repository/token.go
+++ b/internal/repository/token.go
@@ -14,16 +14,16 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-type tokenRepository struct {
+type TokenRepository struct {
 	db *sqlx.DB
 }
 
-func NewTokenRepository(db *sqlx.DB) *tokenRepository {
-	return &tokenRepository{db: db}
+func NewTokenRepository(db *sqlx.DB) *TokenRepository {
+	return &TokenRepository{db: db}
 }
 
 // InsertToken добавляет новый refresh токен в БД.
-func (r *tokenRepository) InsertToken(
+func (r *TokenRepository) InsertToken(
 	ctx context.Context,
 	token entity.RefreshToken,
 ) error {
@@ -47,7 +47,7 @@ func (r *tokenRepository) InsertToken(
 }
 
 // GetActivesTokenByUserID получает список активных refresh токенов пользователя по userID.
-func (r *tokenRepository) GetActivesTokenByUserID(
+func (r *TokenRepository) GetActivesTokenByUserID(
 	ctx context.Context,
 	userID uint,
 ) ([]entity.RefreshToken, error) {
@@ -77,7 +77,7 @@ func (r *tokenRepository) GetActivesTokenByUserID(
 }
 
 // RevokeActivesByUserID помечает все активные refresh токены пользователя как отозванные.
-func (r *tokenRepository) RevokeActivesByUserID(
+func (r *TokenRepository) RevokeActivesByUserID(
 	ctx context.Context,
 	userID uint,
 ) error {
@@ -107,7 +107,7 @@ func (r *tokenRepository) RevokeActivesByUserID(
 }
 
 // GetByUUID находит refresh токен по его UUID.
-func (r *tokenRepository) GetByUUID(
+func (r *TokenRepository) GetByUUID(
 	ctx context.Context,
 	uuid string,
 ) (entity.RefreshToken, error) {
@@ -131,7 +131,7 @@ func (r *tokenRepository) GetByUUID(
 }
 
 // Update обновляет refresh токен.
-func (r *tokenRepository) Update(
+func (r *TokenRepository) Update(
 	ctx context.Context,
 	refresh entity.RefreshToken,
 ) (entity.RefreshToken, error) {

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -15,16 +15,16 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-type userRepository struct {
+type UserRepository struct {
 	db *sqlx.DB
 }
 
-func NewUserRepository(db *sqlx.DB) *userRepository {
-	return &userRepository{db: db}
+func NewUserRepository(db *sqlx.DB) *UserRepository {
+	return &UserRepository{db: db}
 }
 
 // InsertUser вставляет пользователя в БД
-func (r *userRepository) InsertUser(
+func (r *UserRepository) InsertUser(
 	ctx context.Context,
 	user user.User,
 ) (uint, error) {
@@ -51,7 +51,7 @@ func (r *userRepository) InsertUser(
 }
 
 // GetUser получает пользователя по почте
-func (r *userRepository) GetUser(
+func (r *UserRepository) GetUser(
 	ctx context.Context,
 	email string,
 ) (entity.User, error) {
@@ -76,7 +76,7 @@ func (r *userRepository) GetUser(
 }
 
 // GetUserByID получает пользователя по айди
-func (r *userRepository) GetUserByID(
+func (r *UserRepository) GetUserByID(
 	ctx context.Context,
 	id uint,
 ) (entity.User, error) {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -4,6 +4,8 @@ import (
 	"log"
 
 	"github.com/EM-Stawberry/Stawberry/config"
+
+	// Import pgx driver to enable database connection via database/sql
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/jmoiron/sqlx"
 )

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -19,11 +19,11 @@ func InitDB(cfg *config.DBConfig) (*sqlx.DB, func()) {
 	db.SetMaxOpenConns(cfg.MaxOpenConns)
 	db.SetMaxIdleConns(cfg.MaxIdleConns)
 
-	close := func() {
+	closer := func() {
 		if err := db.Close(); err != nil {
 			log.Printf("Error closing database: %v", err)
 		}
 	}
 
-	return db, close
+	return db, closer
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -27,6 +27,7 @@ type DisabledCore struct {
 
 // With overrides the With method to ignore all fields
 func (c DisabledCore) With(fields []zapcore.Field) zapcore.Core {
+	_ = fields
 	return c
 }
 
@@ -40,6 +41,7 @@ func (c DisabledCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcor
 
 // Write overrides the Write method to ignore all fields
 func (c DisabledCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	_ = fields
 	return c.Core.Write(ent, nil)
 }
 

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -90,13 +90,23 @@ func decodeArgon2id(encodedHash string) (param, []byte, []byte, error) {
 	if err != nil {
 		return param{}, nil, nil, err
 	}
-	p.saltSize = uint32(len(salt))
+	saltLen := len(salt)
+	if saltLen > int(^uint32(0)) {
+		return param{}, nil, nil, errors.New("salt length exceeds maximum uint32 value")
+	}
+	p.saltSize = uint32(saltLen)
 
 	hash, err := base64.RawStdEncoding.Strict().DecodeString(vals[5])
 	if err != nil {
 		return param{}, nil, nil, err
 	}
-	p.keyLen = uint32(len(hash))
+
+	hashLen := len(hash)
+	if hashLen > int(^uint32(0)) {
+		return param{}, nil, nil, errors.New("hash length exceeds maximum uint32 value")
+	}
+
+	p.keyLen = uint32(hashLen)
 
 	return p, salt, hash, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,8 +16,9 @@ import (
 
 func StartServer(router *gin.Engine, cfg *config.ServerConfig) error {
 	srv := &http.Server{
-		Addr:    ":" + cfg.Port,
-		Handler: router,
+		Addr:              ":" + cfg.Port,
+		Handler:           router,
+		ReadHeaderTimeout: 3 * time.Second,
 	}
 
 	switch cfg.GinMode {


### PR DESCRIPTION
Активированы временно отключённые линтеры. Все места в коде, на которые линтеры ругались — поправлены. После вливания таски можно будет включать прохождение линтеров как обязательный чек CI/CD.

Для ревьюеров: возможно будет удобнее смотреть изменения покоммитно. Каждый коммит = однотипные изменения для одного и того же правила линтера.