### PR TITLE
Фича: создание оффера.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,7 +26,12 @@ linters:
     gosec:
       excludes:
         - G115
-        
+  exclusions:
+    rules:
+      - path: "docs/"
+        linters:
+          - lll
+
 formatters:
   enable:
     - gofmt # checks if the code is formatted according to 'gofmt' command

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -47,7 +47,7 @@ func main() {
 	db, closer := database.InitDB(&cfg.DB)
 	defer closer()
 
-	migrator.RunMigrationsWithZap(db, "../../migrations", log)
+	migrator.RunMigrationsWithZap(db, "migrations", log)
 
 	database.SeedDatabase(cfg, db, log)
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -526,7 +526,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/offers/user": {
+        "/offers": {
             "get": {
                 "consumes": [
                     "application/json"
@@ -563,6 +563,61 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offer"
+                ],
+                "summary": "Create offer",
+                "parameters": [
+                    {
+                        "description": "Offer creation request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.PostOfferReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.PostOfferResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/apperror.Error"
                         }
@@ -918,6 +973,38 @@ const docTemplate = `{
             "properties": {
                 "new_status": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.PostOfferReq": {
+            "type": "object",
+            "required": [
+                "currency",
+                "price",
+                "product_id",
+                "shop_id"
+            ],
+            "properties": {
+                "currency": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "product_id": {
+                    "type": "integer"
+                },
+                "shop_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.PostOfferResp": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -515,7 +515,7 @@
                 }
             }
         },
-        "/offers/user": {
+        "/offers": {
             "get": {
                 "consumes": [
                     "application/json"
@@ -552,6 +552,61 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Error"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "offer"
+                ],
+                "summary": "Create offer",
+                "parameters": [
+                    {
+                        "description": "Offer creation request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/dto.PostOfferReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/dto.PostOfferResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "$ref": "#/definitions/apperror.Error"
                         }
@@ -907,6 +962,38 @@
             "properties": {
                 "new_status": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.PostOfferReq": {
+            "type": "object",
+            "required": [
+                "currency",
+                "price",
+                "product_id",
+                "shop_id"
+            ],
+            "properties": {
+                "currency": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "product_id": {
+                    "type": "integer"
+                },
+                "shop_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "dto.PostOfferResp": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -97,6 +97,28 @@ definitions:
       new_status:
         type: string
     type: object
+  dto.PostOfferReq:
+    properties:
+      currency:
+        type: string
+      price:
+        minimum: 0
+        type: number
+      product_id:
+        type: integer
+      shop_id:
+        type: integer
+    required:
+    - currency
+    - price
+    - product_id
+    - shop_id
+    type: object
+  dto.PostOfferResp:
+    properties:
+      id:
+        type: integer
+    type: object
   dto.RefreshReq:
     properties:
       fingerprint:
@@ -532,6 +554,75 @@ paths:
       summary: Получить статус сервера
       tags:
       - health
+  /offers:
+    get:
+      consumes:
+      - application/json
+      parameters:
+      - default: 1
+        description: Page number for pagination
+        in: query
+        name: page
+        type: integer
+      - default: 10
+        description: Number of items per page (5-100)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.GetUserOffersResp'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apperror.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apperror.Error'
+      summary: Get user's offers
+      tags:
+      - offer
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Offer creation request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dto.PostOfferReq'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dto.PostOfferResp'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apperror.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/apperror.Error'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/apperror.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apperror.Error'
+      summary: Create offer
+      tags:
+      - offer
   /offers/{offerID}:
     patch:
       consumes:
@@ -576,39 +667,6 @@ paths:
           schema:
             $ref: '#/definitions/apperror.Error'
       summary: Update offer status
-      tags:
-      - offer
-  /offers/user:
-    get:
-      consumes:
-      - application/json
-      parameters:
-      - default: 1
-        description: Page number for pagination
-        in: query
-        name: page
-        type: integer
-      - default: 10
-        description: Number of items per page (5-100)
-        in: query
-        name: limit
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/dto.GetUserOffersResp'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/apperror.Error'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/apperror.Error'
-      summary: Get user's offers
       tags:
       - offer
   /products:

--- a/integration/offer/offer_test.go
+++ b/integration/offer/offer_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/EM-Stawberry/Stawberry/pkg/email"
+
 	"github.com/EM-Stawberry/Stawberry/internal/handler/helpers"
 
 	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
@@ -105,6 +107,8 @@ func mockAuthShopOwnerMiddleware() gin.HandlerFunc {
 		c.Set("user", mockUser)
 		c.Set(helpers.UserIDKey, uint(1))
 		c.Set(helpers.UserIsStoreKey, true)
+		c.Set(helpers.UserName, "user1")
+		c.Set(helpers.UserEmail, "user1email")
 		c.Next()
 	}
 }
@@ -122,6 +126,8 @@ func mockAuthBuyerMiddleware() gin.HandlerFunc {
 		c.Set("user", mockUser)
 		c.Set(helpers.UserIDKey, uint(2))
 		c.Set(helpers.UserIsStoreKey, false)
+		c.Set(helpers.UserName, "user2")
+		c.Set(helpers.UserEmail, "user2email")
 		c.Next()
 	}
 }
@@ -139,21 +145,70 @@ func mockAuthIncorrectShopOwnerMiddleware() gin.HandlerFunc {
 		c.Set("user", mockUser)
 		c.Set(helpers.UserIDKey, uint(3))
 		c.Set(helpers.UserIsStoreKey, true)
+		c.Set(helpers.UserName, "user3")
+		c.Set(helpers.UserEmail, "user3email")
 		c.Next()
 	}
 }
 
-var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
-	dbCont := GetContainer()
-	db, err := GetDB(dbCont)
-	if err != nil {
-		slog.Error(err.Error())
-		return
-	}
+type mockMailer struct{}
 
-	offerRepo := repository.NewOfferRepository(db)
-	offerServ := offer.NewService(offerRepo, nil)
-	offerHand := handler.NewOfferHandler(offerServ)
+func newMockMailer() email.MailerService {
+	return &mockMailer{}
+}
+
+func (m *mockMailer) Registered(userName string, userMail string) {
+}
+
+func (m *mockMailer) StatusUpdate(offerID uint, status string, userMail string) {
+}
+
+func (m *mockMailer) OfferReceived(offerID uint, userMail string) {
+}
+
+func (m *mockMailer) Stop(ctx context.Context) {
+}
+
+func setupRouter(authMiddleware gin.HandlerFunc, method, path string, handlerFunc gin.HandlerFunc) *gin.Engine {
+	router := gin.Default()
+	router.Use(middleware.Errors())
+	router.Use(authMiddleware)
+
+	switch method {
+	case http.MethodPatch:
+		router.PATCH(path, handlerFunc)
+	case http.MethodPost:
+		router.POST(path, handlerFunc)
+	default:
+		panic(fmt.Sprintf("unsupported HTTP method: %s", method))
+	}
+	return router
+}
+
+var _ = ginkgo.Describe("offer handlers", ginkgo.Ordered, func() {
+	var (
+		dbCont    *postgres.PostgresContainer
+		db        *sqlx.DB
+		offerRepo offer.Repository
+		offerServ *offer.Service
+		offerHand *handler.OfferHandler
+		router    *gin.Engine
+	)
+
+	ginkgo.BeforeAll(func() {
+		dbCont = GetContainer()
+		var err error
+		db, err = GetDB(dbCont)
+		if err != nil {
+			slog.Error(err.Error())
+			ginkgo.Fail("Failed to get database connection")
+		}
+		mailer := newMockMailer()
+
+		offerRepo = repository.NewOfferRepository(db)
+		offerServ = offer.NewService(offerRepo, mailer)
+		offerHand = handler.NewOfferHandler(offerServ)
+	})
 
 	ginkgo.AfterAll(func() {
 		_ = db.Close()
@@ -161,12 +216,10 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.Context("when the user is the shop owner", func() {
-
-		gin.SetMode(gin.ReleaseMode)
-		router := gin.New()
-		router.Use(middleware.Errors())
-		router.Use(mockAuthShopOwnerMiddleware())
-		router.PATCH("/api/test/offers/:offerID/status-update", offerHand.PatchOfferStatus)
+		ginkgo.BeforeEach(func() {
+			router = setupRouter(mockAuthShopOwnerMiddleware(),
+				http.MethodPatch, "/api/test/offers/:offerID", offerHand.PatchOfferStatus)
+		})
 
 		ginkgo.It("successfully updates the offer status if everything is fine", func() {
 			correctOfferID := 1
@@ -178,7 +231,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", correctOfferID),
+				fmt.Sprintf("/api/test/offers/%d", correctOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -192,7 +245,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			gomega.Expect(ofr.NewStatus).To(gomega.Equal("accepted"))
 		})
 
-		ginkgo.It("fails data validation if the is negative", func() {
+		ginkgo.It("fails data validation if the offerID is negative", func() {
 			badOfferID := -2
 			correctStatus := "accepted"
 			jsonBody, _ := json.Marshal(struct {
@@ -202,7 +255,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", badOfferID),
+				fmt.Sprintf("/api/test/offers/%d", badOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -212,7 +265,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			gomega.Expect(rec.Code).To(gomega.Equal(http.StatusBadRequest))
 		})
 
-		ginkgo.It("fails data validation if the is non-numeric", func() {
+		ginkgo.It("fails data validation if the offerID is non-numeric", func() {
 			badOfferID := "two"
 			correctStatus := "accepted"
 			jsonBody, _ := json.Marshal(struct {
@@ -222,7 +275,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%s/status-update", badOfferID),
+				fmt.Sprintf("/api/test/offers/%s", badOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -232,7 +285,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			gomega.Expect(rec.Code).To(gomega.Equal(http.StatusBadRequest))
 		})
 
-		ginkgo.It("fails data validation if the status is not accepted/declined", func() {
+		ginkgo.It("fails data validation if the status is not `accepted` or `declined`", func() {
 			correctOfferID := 4
 			badStatus := "bad_status"
 			jsonBody, _ := json.Marshal(struct {
@@ -242,7 +295,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", correctOfferID),
+				fmt.Sprintf("/api/test/offers/%d", correctOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -257,7 +310,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			malformedJSON := []byte(`{"status": "accepted"`)
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", correctOfferID),
+				fmt.Sprintf("/api/test/offers/%d", correctOfferID),
 				bytes.NewBuffer(malformedJSON))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -277,7 +330,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", badOfferID),
+				fmt.Sprintf("/api/test/offers/%d", badOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -297,7 +350,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", correctOfferID),
+				fmt.Sprintf("/api/test/offers/%d", correctOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -309,12 +362,10 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.Context("when the user is an owner of a different shop", func() {
-
-		router := gin.New()
-		gin.SetMode(gin.ReleaseMode)
-		router.Use(middleware.Errors())
-		router.Use(mockAuthIncorrectShopOwnerMiddleware())
-		router.PATCH("/api/test/offers/:offerID/status-update", offerHand.PatchOfferStatus)
+		ginkgo.BeforeEach(func() {
+			router = setupRouter(mockAuthIncorrectShopOwnerMiddleware(),
+				http.MethodPatch, "/api/test/offers/:offerID", offerHand.PatchOfferStatus)
+		})
 
 		ginkgo.It("fails to update the offer status, even if everything is fine", func() {
 			correctOfferID := 2
@@ -326,7 +377,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", correctOfferID),
+				fmt.Sprintf("/api/test/offers/%d", correctOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -339,13 +390,10 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.Context("when a user is the creator of an offer", func() {
-
-		gin.SetMode(gin.ReleaseMode)
-		router := gin.New()
-
-		router.Use(middleware.Errors())
-		router.Use(mockAuthBuyerMiddleware())
-		router.PATCH("/api/test/offers/:offerID/status-update", offerHand.PatchOfferStatus)
+		ginkgo.BeforeEach(func() {
+			router = setupRouter(mockAuthBuyerMiddleware(),
+				http.MethodPatch, "/api/test/offers/:offerID", offerHand.PatchOfferStatus)
+		})
 
 		ginkgo.It("updates the status to `cancelled` if the request is correct", func() {
 			correctOfferID := 2
@@ -357,7 +405,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", correctOfferID),
+				fmt.Sprintf("/api/test/offers/%d", correctOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -371,7 +419,8 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			gomega.Expect(ofr.NewStatus).To(gomega.Equal("cancelled"))
 		})
 
-		ginkgo.It("fails to update the status to `accepted`, since that status can only be used by shop owner", func() {
+		ginkgo.It("fails to update the status to `accepted`, "+
+			"since that status can only be used by shop owner", func() {
 			correctOfferID := 3
 			correctStatus := "accepted"
 			jsonBody, _ := json.Marshal(struct {
@@ -381,7 +430,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", correctOfferID),
+				fmt.Sprintf("/api/test/offers/%d", correctOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -393,13 +442,10 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 	})
 
 	ginkgo.Context("when a user is NOT the creator of an offer", func() {
-
-		gin.SetMode(gin.ReleaseMode)
-		router := gin.New()
-
-		router.Use(middleware.Errors())
-		router.Use(mockAuthBuyerMiddleware())
-		router.PATCH("/api/test/offers/:offerID/status-update", offerHand.PatchOfferStatus)
+		ginkgo.BeforeEach(func() {
+			router = setupRouter(mockAuthBuyerMiddleware(),
+				http.MethodPatch, "/api/test/offers/:offerID", offerHand.PatchOfferStatus)
+		})
 
 		ginkgo.It("updates the status to `cancelled` if the request is correct", func() {
 			correctOfferID := 5
@@ -411,7 +457,7 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			})
 
 			req := httptest.NewRequest(http.MethodPatch,
-				fmt.Sprintf("/api/test/offers/%d/status-update", correctOfferID),
+				fmt.Sprintf("/api/test/offers/%d", correctOfferID),
 				bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
@@ -419,6 +465,97 @@ var _ = ginkgo.Describe("offer patch status handler", ginkgo.Ordered, func() {
 			router.ServeHTTP(rec, req)
 
 			gomega.Expect(rec.Code).To(gomega.Equal(http.StatusNotFound))
+		})
+	})
+
+	ginkgo.Context("Offer Post Handler for buyers", ginkgo.Ordered, func() {
+		ginkgo.BeforeEach(func() {
+			router = setupRouter(mockAuthBuyerMiddleware(),
+				http.MethodPost, "/api/test/offers", offerHand.PostOffer)
+		})
+
+		ginkgo.It("successfully creates an offer with valid data", func() {
+			reqBody := dto.PostOfferReq{
+				ProductID: 1,
+				ShopID:    2,
+				Price:     100.50,
+				Currency:  "USD",
+			}
+			jsonBody, _ := json.Marshal(reqBody)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/test/offers", bytes.NewBuffer(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			gomega.Expect(rec.Code).To(gomega.Equal(http.StatusCreated))
+
+			var resp dto.PostOfferResp
+			err := json.Unmarshal(rec.Body.Bytes(), &resp)
+			gomega.Expect(err).To(gomega.BeNil())
+			gomega.Expect(resp.ID).To(gomega.BeNumerically(">", 0)) // Expect a positive ID
+		})
+
+		ginkgo.It("fails to create an offer with a negative price", func() {
+			reqBody := dto.PostOfferReq{
+				ProductID: 2,
+				ShopID:    2,
+				Price:     -10.00,
+				Currency:  "USD",
+			}
+			jsonBody, _ := json.Marshal(reqBody)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/test/offers", bytes.NewBuffer(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			gomega.Expect(rec.Code).To(gomega.Equal(http.StatusBadRequest))
+		})
+
+		ginkgo.It("fails to create an offer with missing required fields (e.g., ProductID)", func() {
+			reqBody := dto.PostOfferReq{
+				// ProductID is missing, which is required by `binding:"required"`
+				ShopID:   2,
+				Price:    100.00,
+				Currency: "USD",
+			}
+			jsonBody, _ := json.Marshal(reqBody)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/test/offers", bytes.NewBuffer(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			gomega.Expect(rec.Code).To(gomega.Equal(http.StatusBadRequest))
+		})
+	})
+
+	ginkgo.Context("Offer Post Handler for shop owners", ginkgo.Ordered, func() {
+		ginkgo.BeforeEach(func() {
+			router = setupRouter(mockAuthIncorrectShopOwnerMiddleware(),
+				http.MethodPost, "/api/test/offers", offerHand.PostOffer)
+		})
+
+		ginkgo.It("fails to create an offer with a shop owner account", func() {
+			reqBody := dto.PostOfferReq{
+				ProductID: 4,
+				ShopID:    2,
+				Price:     100.50,
+				Currency:  "USD",
+			}
+			jsonBody, _ := json.Marshal(reqBody)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/test/offers", bytes.NewBuffer(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			gomega.Expect(rec.Code).To(gomega.Equal(http.StatusForbidden))
 		})
 	})
 })

--- a/integration/testdata/offer/sql/populate_test_db.sql
+++ b/integration/testdata/offer/sql/populate_test_db.sql
@@ -13,11 +13,19 @@ insert into categories (name, lft, rgt, parent_id) values ('test_cat', 1, 1, 1);
 
 insert into products (name, category_id, description) VALUES ('product1', 1, 'description1');
 insert into products (name, category_id, description) VALUES ('product2', 1, 'description2');
+insert into products (name, category_id, description) VALUES ('product3', 1, 'description3');
+insert into products (name, category_id, description) VALUES ('product4', 1, 'description4');
 
 insert into shop_inventory (product_id, shop_id, is_available, price, currency) VALUES (1, 1, true, 100.00, 'usd');
 insert into shop_inventory (product_id, shop_id, is_available, price, currency) VALUES (2, 1, true, 120.00, 'usd');
+insert into shop_inventory (product_id, shop_id, is_available, price, currency) VALUES (3, 1, true, 150.00, 'usd');
+insert into shop_inventory (product_id, shop_id, is_available, price, currency) VALUES (4, 1, true, 180.00, 'usd');
+insert into shop_inventory (product_id, shop_id, is_available, price, currency) VALUES (1, 2, true, 100.00, 'usd');
+insert into shop_inventory (product_id, shop_id, is_available, price, currency) VALUES (2, 2, true, 120.00, 'usd');
+insert into shop_inventory (product_id, shop_id, is_available, price, currency) VALUES (3, 2, true, 150.00, 'usd');
+insert into shop_inventory (product_id, shop_id, is_available, price, currency) VALUES (4, 2, true, 180.00, 'usd');
 
 insert into offers (offer_price, currency, status, created_at, updated_at, user_id, product_id, shop_id) VALUES (55, 'usd', default, default, default, 2, 1, 1);
-insert into offers (offer_price, currency, status, created_at, updated_at, user_id, product_id, shop_id) VALUES (65, 'usd', default, default, default, 2, 1, 1);
-insert into offers (offer_price, currency, status, created_at, updated_at, user_id, product_id, shop_id) VALUES (45, 'usd', default, default, default, 2, 2, 1);
-insert into offers (offer_price, currency, status, created_at, updated_at, user_id, product_id, shop_id) VALUES (48, 'usd', default, default, default, 2, 2, 1);
+insert into offers (offer_price, currency, status, created_at, updated_at, user_id, product_id, shop_id) VALUES (65, 'usd', default, default, default, 2, 2, 1);
+insert into offers (offer_price, currency, status, created_at, updated_at, user_id, product_id, shop_id) VALUES (45, 'usd', default, default, default, 2, 3, 1);
+insert into offers (offer_price, currency, status, created_at, updated_at, user_id, product_id, shop_id) VALUES (48, 'usd', default, default, default, 2, 4, 1);

--- a/internal/app/apperror/errors.go
+++ b/internal/app/apperror/errors.go
@@ -14,6 +14,7 @@ const (
 	InvalidToken       = "INVALID_TOKEN"
 	InvalidFingerprint = "INVALID_FINGERPRINT"
 	Conflict           = "CONFLICT"
+	Forbidden          = "FORBIDDEN"
 )
 
 type AppError interface {

--- a/internal/handler/dto/offer.go
+++ b/internal/handler/dto/offer.go
@@ -7,11 +7,10 @@ import (
 )
 
 type PostOfferReq struct {
-	UserID    uint    `json:"user_id" binding:"required"`
 	ProductID uint    `json:"product_id" binding:"required"`
-	StoreID   uint    `json:"store_id" binding:"required"`
-	Price     float64 `json:"offer_price" binding:"required"`
-	Currency  string  `json:"currency" binding:"required"`
+	ShopID    uint    `json:"shop_id" binding:"required"`
+	Price     float64 `json:"price" binding:"required,gte=0"`
+	Currency  string  `json:"currency" binding:"required,iso4217"`
 }
 
 type PostOfferResp struct {
@@ -22,8 +21,7 @@ func (po *PostOfferReq) ConvertToEntity() entity.Offer {
 	return entity.Offer{
 		Price:     po.Price,
 		Currency:  po.Currency,
-		ShopID:    po.StoreID,
-		UserID:    po.UserID,
+		ShopID:    po.ShopID,
 		ProductID: po.ProductID,
 	}
 }

--- a/internal/handler/helpers/auth.go
+++ b/internal/handler/helpers/auth.go
@@ -6,6 +6,8 @@ const (
 	UserIDKey      = "userID"
 	UserIsStoreKey = "userIsStore"
 	UserIsAdminKey = "userIsAdmin"
+	UserName       = "userName"
+	UserEmail      = "userEmail"
 )
 
 func UserIDContext(c *gin.Context) (uint, bool) {
@@ -42,4 +44,28 @@ func UserIsStoreContext(c *gin.Context) (bool, bool) {
 		return false, false
 	}
 	return isStoreValue, true
+}
+
+func UserNameContext(c *gin.Context) (string, bool) {
+	name, exists := c.Get(UserName)
+	if !exists {
+		return "", false
+	}
+	nameValue, ok := name.(string)
+	if !ok {
+		return "", false
+	}
+	return nameValue, true
+}
+
+func UserEmailContext(c *gin.Context) (string, bool) {
+	email, exists := c.Get(UserEmail)
+	if !exists {
+		return "", false
+	}
+	emailValue, ok := email.(string)
+	if !ok {
+		return "", false
+	}
+	return emailValue, true
 }

--- a/internal/handler/middleware/auth.go
+++ b/internal/handler/middleware/auth.go
@@ -58,6 +58,8 @@ func AuthMiddleware(userGetter UserGetter, validator TokenValidator) gin.Handler
 
 		c.Set(helpers.UserIDKey, user.ID)
 		c.Set(helpers.UserIsStoreKey, user.IsStore)
+		c.Set(helpers.UserName, user.Name)
+		c.Set(helpers.UserEmail, user.Email)
 
 		c.Set(helpers.UserIsAdminKey, false)
 		c.Next()

--- a/internal/handler/middleware/error.go
+++ b/internal/handler/middleware/error.go
@@ -55,6 +55,8 @@ func errorStatus(code string) int {
 		return http.StatusUnauthorized
 	case apperror.Conflict:
 		return http.StatusConflict
+	case apperror.Forbidden:
+		return http.StatusForbidden
 	case apperror.InternalError:
 		fallthrough
 

--- a/migrations/20250528001833_offers_shop_index.sql
+++ b/migrations/20250528001833_offers_shop_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX idx_offers_shop_id ON offers (shop_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX idx_offers_shop_id;
+-- +goose StatementEnd


### PR DESCRIPTION
### Из глобальных изменений:

- Доабавлен валидатор кодов валют по iso 4217 (api.go)

### Остальное:

- PostOffer функционал. 
  - Аккаунты - владельцы магазинов не могут создавать офферы.
  - Валидация входных параметров через json-теги
  - Тесты в ./integration/offer/offer_test.go, плюс обновленный пресет тестовых данных (дабы удовлетворять новому unique индексу)
  - Переместил объявление роутов в RegisterRoutes
  - Добавил http.statusForbidden в обработчик ошибок
## upd (28.05):
Добавлен проброс имени и адреса почты юзера в мидлваре авторизации (самый простой способ получить эти данные для отправки имейла из оффер сервиса)