### PR TITLE
Фича: получить все активные офферы юзера.

### DIFF
--- a/internal/domain/service/offer/offer.go
+++ b/internal/domain/service/offer/offer.go
@@ -2,7 +2,6 @@ package offer
 
 import (
 	"context"
-
 	"github.com/EM-Stawberry/Stawberry/internal/app/apperror"
 	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
 	"github.com/EM-Stawberry/Stawberry/pkg/email"
@@ -11,7 +10,7 @@ import (
 type Repository interface {
 	InsertOffer(ctx context.Context, offer Offer) (uint, error)
 	GetOfferByID(ctx context.Context, offerID uint) (entity.Offer, error)
-	SelectUserOffers(ctx context.Context, userID uint, limit, offset int) ([]entity.Offer, int64, error)
+	SelectUserOffers(ctx context.Context, userID uint, limit, offset int) ([]entity.Offer, int, error)
 	UpdateOfferStatus(ctx context.Context, offer entity.Offer, userID uint, isStore bool) (entity.Offer, error)
 	DeleteOffer(ctx context.Context, offerID uint) (entity.Offer, error)
 }
@@ -48,10 +47,15 @@ func (os *Service) GetOffer(
 func (os *Service) GetUserOffers(
 	ctx context.Context,
 	userID uint,
-	limit,
-	offset int,
-) ([]entity.Offer, int64, error) {
-	return os.offerRepository.SelectUserOffers(ctx, userID, limit, offset)
+	page,
+	limit int,
+) ([]entity.Offer, int, error) {
+	offset := (page - 1) * limit
+
+	offers, total, err := os.offerRepository.SelectUserOffers(ctx, userID, limit, offset)
+
+	return offers, total, err
+
 }
 
 func (os *Service) UpdateOfferStatus(

--- a/internal/domain/service/offer/offer.go
+++ b/internal/domain/service/offer/offer.go
@@ -2,6 +2,7 @@ package offer
 
 import (
 	"context"
+
 	"github.com/EM-Stawberry/Stawberry/internal/app/apperror"
 	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
 	"github.com/EM-Stawberry/Stawberry/pkg/email"

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -74,6 +74,7 @@ func SetupRouter(
 	// эндпойнты запросов на покупку
 	{
 		secured.PATCH("offers/:offerID", offerH.PatchOfferStatus)
+		secured.GET("offers/user", offerH.GetUserOffers)
 	}
 
 	// эндпойнты отзывов

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -74,7 +74,7 @@ func SetupRouter(
 	// эндпойнты запросов на покупку
 	{
 		secured.PATCH("offers/:offerID", offerH.PatchOfferStatus)
-		secured.GET("offers/user", offerH.GetUserOffers)
+		secured.GET("offers", offerH.GetUserOffers)
 	}
 
 	// эндпойнты отзывов

--- a/internal/handler/dto/offer.go
+++ b/internal/handler/dto/offer.go
@@ -1,8 +1,9 @@
 package dto
 
 import (
-	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
 	"time"
+
+	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
 )
 
 type PostOfferReq struct {

--- a/internal/handler/dto/offer.go
+++ b/internal/handler/dto/offer.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"github.com/EM-Stawberry/Stawberry/internal/domain/entity"
+	"time"
 )
 
 type PostOfferReq struct {
@@ -46,4 +47,57 @@ func (p *PatchOfferStatusReq) ConvertToEntity() entity.Offer {
 
 func ConvertToPatchOfferStatusResp(o entity.Offer) PatchOfferStatusResp {
 	return PatchOfferStatusResp{NewStatus: o.Status}
+}
+
+type OfferResp struct {
+	ID        uint
+	Price     float64
+	Currency  string
+	Status    string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	ShopID    uint
+	ProductID uint
+}
+
+type GetUserOffersResp struct {
+	Data []OfferResp `json:"data"`
+	Meta struct {
+		CurrentPage int `json:"current_page"`
+		PerPage     int `json:"per_page"`
+		TotalItems  int `json:"total_items"`
+		TotalPages  int `json:"total_pages"`
+	}
+}
+
+func FormUserOffers(ofrs []entity.Offer, page, limit, total, totalPages int) GetUserOffersResp {
+	data := make([]OfferResp, len(ofrs))
+
+	for i, ofr := range ofrs {
+		data[i] = OfferResp{
+			ID:        ofr.ID,
+			Price:     ofr.Price,
+			Currency:  ofr.Currency,
+			Status:    ofr.Status,
+			CreatedAt: ofr.CreatedAt,
+			ExpiresAt: ofr.ExpiresAt,
+			ShopID:    ofr.ShopID,
+			ProductID: ofr.ProductID,
+		}
+	}
+
+	return GetUserOffersResp{
+		Data: data,
+		Meta: struct {
+			CurrentPage int `json:"current_page"`
+			PerPage     int `json:"per_page"`
+			TotalItems  int `json:"total_items"`
+			TotalPages  int `json:"total_pages"`
+		}{
+			CurrentPage: page,
+			PerPage:     limit,
+			TotalItems:  total,
+			TotalPages:  totalPages,
+		},
+	}
 }

--- a/internal/handler/dto/offer.go
+++ b/internal/handler/dto/offer.go
@@ -71,10 +71,10 @@ type GetUserOffersResp struct {
 }
 
 func FormUserOffers(ofrs []entity.Offer, page, limit, total, totalPages int) GetUserOffersResp {
-	data := make([]OfferResp, len(ofrs))
+	data := make([]OfferResp, 0, len(ofrs))
 
-	for i, ofr := range ofrs {
-		data[i] = OfferResp{
+	for _, ofr := range ofrs {
+		data = append(data, OfferResp{
 			ID:        ofr.ID,
 			Price:     ofr.Price,
 			Currency:  ofr.Currency,
@@ -83,7 +83,7 @@ func FormUserOffers(ofrs []entity.Offer, page, limit, total, totalPages int) Get
 			ExpiresAt: ofr.ExpiresAt,
 			ShopID:    ofr.ShopID,
 			ProductID: ofr.ProductID,
-		}
+		})
 	}
 
 	return GetUserOffersResp{

--- a/internal/handler/offer.go
+++ b/internal/handler/offer.go
@@ -64,6 +64,16 @@ func (h *OfferHandler) PostOffer(c *gin.Context) {
 	c.JSON(http.StatusCreated, offer)
 }
 
+// @summary Get user's offers
+// @tags offer
+// @accept json
+// @produce json
+// @param page query int false "Page number for pagination" default(1)
+// @param limit query int false "Number of items per page (5-100)" default(10)
+// @success 200 {object} dto.GetUserOffersResp
+// @failure 400 {object} apperror.Error
+// @failure 500 {object} apperror.Error
+// @Router /offers/user [get]
 func (h *OfferHandler) GetUserOffers(c *gin.Context) {
 	ctx, canc := context.WithTimeout(c.Request.Context(), time.Second*30)
 	defer canc()

--- a/internal/repository/model/offer.go
+++ b/internal/repository/model/offer.go
@@ -19,6 +19,11 @@ type Offer struct {
 	ProductID uint      `db:"product_id"`
 }
 
+type OfferWithCount struct {
+	Offer
+	TotalCount int `db:"total_count"`
+}
+
 func (o *Offer) ConvertToEntity() entity.Offer {
 	return entity.Offer{
 		ID:        o.ID,

--- a/migrations/20250528120134_add_created_at_index.sql
+++ b/migrations/20250528120134_add_created_at_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX idx_offers_created_at ON offers(created_at);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_offers_created_at;
+-- +goose StatementEnd

--- a/migrations/20250528120134_add_offer_indexes.sql
+++ b/migrations/20250528120134_add_offer_indexes.sql
@@ -1,9 +1,11 @@
 -- +goose Up
 -- +goose StatementBegin
 CREATE INDEX idx_offers_created_at ON offers(created_at);
+CREATE INDEX idx_offers_expires_at ON offers(expires_at);
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 DROP INDEX IF EXISTS idx_offers_created_at;
+DROP INDEX IF EXISTS idx_offers_expires_at;
 -- +goose StatementEnd


### PR DESCRIPTION
- Получение всех активных офферов юзера, с пагинацией. 
- Получение офферов и их общего кол-ва за один поход к бд (для этого появилась новая структурка в `./repository/models/`).
- Форматирование API-ответа с метаданными пагинации. 
- Добавлены два новых индекса базы данных по `offers.created_at` и `offers.expires_at` для улучшения производительности.
- Обновление устаревших офферов при чтении (ленивое обновление).